### PR TITLE
Add codecov configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ before_script:
 
 script:
   - vendor/bin/phpunit --coverage-clover clover
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Add codecove configuration to show the coverage report. Please add your repo to codecov.io and you are good to go.